### PR TITLE
fixing broken URL

### DIFF
--- a/docs/optional_labs/ocp_image_registry.md
+++ b/docs/optional_labs/ocp_image_registry.md
@@ -293,7 +293,7 @@ We will need to create kubernetes resources to use the Objects store as the OCP 
 2. Create a connection to your OCP cluster (if not already done so)
 
    ```bash
-   export KUBECONFIG=/root/xyz/auth/kubeconfig
+   export KUBECONFIG=/home/ubuntu/ocpuserXX/auth/kubeconfig
    ```
    List the nodes in the cluster to make sure the connection is working
 
@@ -314,7 +314,7 @@ We will need to create kubernetes resources to use the Objects store as the OCP 
 11. Create a config map 
 
      ```bash
-     oc create configmap object-ca --from-file=ca-bundle.crt=rootCA.crt -n openshift-config 
+     oc create configmap object-ca --from-file=ca-bundle.crt=rootCA.pem -n openshift-config 
      ```
 
      ```buttonless title="Output"

--- a/docs/workloads_on_ocp/ocp_k10.md
+++ b/docs/workloads_on_ocp/ocp_k10.md
@@ -90,7 +90,7 @@ We will start by creating a VolumeSnapshotClass kubernetes object with Nutanix C
     # Add kasten helm repo
     helm repo add kasten https://charts.kasten.io/
     # Run kasten pre-install check
-    curl https://docs.kasten.io/tools/k10_primer.sh | bash
+    curl https://docs.kasten.io/downloads/8.0.2/tools/k10_primer.sh | bash
     ```
 
 5.  You would notice output as following:


### PR DESCRIPTION
URL doesn't work (https://docs.kasten.io/tools/k10_primer.sh). 

Kasten docs (https://docs.kasten.io/latest/install/requirements), show the following URL: https://docs.kasten.io/downloads/8.0.2/tools/k10_primer.sh


